### PR TITLE
xgettext: remove dependency on libstdc++-6 because of thread safety

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,7 @@ jobs:
           ../configure \
             CPPFLAGS='${{ steps.vars.outputs.cpp-flags }}' \
             LDFLAGS='${{ steps.vars.outputs.ld-flags }}' \
+            CXXFLAGS='${{ steps.vars.outputs.cxx-flags }}' \
             ${{ steps.vars.outputs.configure-args }} \
             --prefix=$INSTALLED_PATH
       -
@@ -199,6 +200,7 @@ jobs:
           ../configure \
             CPPFLAGS="-I$INSTALLED_PATH/include ${{ steps.vars.outputs.cpp-flags }}" \
             LDFLAGS="-L$INSTALLED_PATH/lib ${{ steps.vars.outputs.ld-flags }}" \
+            CXXFLAGS='${{ steps.vars.outputs.cxx-flags }}' \
             ${{ steps.vars.outputs.configure-args }} \
             --disable-java \
             --disable-native-java \

--- a/build-exe/vars.ps1
+++ b/build-exe/vars.ps1
@@ -45,7 +45,7 @@ $configureArgs = @(
     '--enable-nls',
     '--disable-rpath',
     '--disable-acl',
-    '--enable-threads=windows'
+    '--disable-threads'
 )
 switch ($Link) {
     'shared' {
@@ -194,6 +194,7 @@ $gnuUrlPrefixer.WriteWarning()
 "configure-args=$configureArgs" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "cpp-flags=-I/usr/$mingwHost/sys-root/mingw/include -g0 -O2" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "ld-flags=-L/usr/$mingwHost/sys-root/mingw/lib" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+"cxx-flags=-fno-threadsafe-statics" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "iconv-source-url=$iconvSourceUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "gettext-source-url=$gettextSourceUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "gettext-ignore-tests-c=$gettextIgnoreTestsC" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/build-exe/vars.ps1
+++ b/build-exe/vars.ps1
@@ -45,7 +45,7 @@ $configureArgs = @(
     '--enable-nls',
     '--disable-rpath',
     '--disable-acl',
-    '--disable-threads'
+    '--enable-threads=windows'
 )
 switch ($Link) {
     'shared' {


### PR DESCRIPTION
When thread safety is enabled, xgettext uses the two functions `__cxa_guard_acquire` and `__cxa_guard_release` of `libstdc++-6.dll`