### PR TITLE
shared 32-bits: avoid MinGW-w64 DLL dependencies

### DIFF
--- a/build-exe/vars.ps1
+++ b/build-exe/vars.ps1
@@ -45,6 +45,7 @@ $configureArgs = @(
     '--enable-nls',
     '--disable-rpath',
     '--disable-acl',
+    'gl_cv_header_working_stdint_h=no',
     '--enable-threads=windows'
 )
 switch ($Link) {
@@ -192,7 +193,7 @@ $gnuUrlPrefixer.WriteWarning()
 "cygwin-path=/usr/$mingwHost/bin:/usr/$mingwHost/sys-root/mingw/bin:/usr/sbin:/usr/bin:/sbin:/bin:/cygdrive/c/Windows/System32:/cygdrive/c/Windows" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "mingw-host=$mingwHost" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "configure-args=$configureArgs" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-"cpp-flags=-I/usr/$mingwHost/sys-root/mingw/include -g0 -O2" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+"cpp-flags=-I/usr/$mingwHost/sys-root/mingw/include -g0 -O2 -D__USE_MINGW_ANSI_STDIO=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "ld-flags=-L/usr/$mingwHost/sys-root/mingw/lib" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "cxx-flags=-fno-threadsafe-statics" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 "iconv-source-url=$iconvSourceUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8


### PR DESCRIPTION
`-D__USE_MINGW_ANSI_STDIO=0` should do that.
That requires `gl_cv_header_working_stdint_h=no` (see https://savannah.gnu.org/bugs/?66232#comment3)