### PR TITLE
Use CLDR 37

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         shell: pwsh
         run: |
           $v = '${{ github.event.inputs.cldr-version }}'.Trim()
-          if ($v -eq '') { $v = '45' }
+          if ($v -eq '') { $v = '37' }
           Write-Output -InputObject "CLDR_VERSION=$v" >>"$env:GITHUB_ENV"
           $v = '${{ github.event.inputs.iconv-version }}'.Trim()
           if ($v -eq '') { $v = '1.17' }


### PR DESCRIPTION
Use CLDR 37 because of bug https://savannah.gnu.org/bugs/?66378
